### PR TITLE
fix: Migrate deprecated onBrokenMarkdownLinks to markdown.hooks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,12 @@ const config = {
   projectName: 'wiki-steami',
 
   onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   i18n: {
     defaultLocale: 'fr',


### PR DESCRIPTION
## Summary

- Migrate `onBrokenMarkdownLinks` from root-level config to `markdown.hooks.onBrokenMarkdownLinks` (deprecated since Docusaurus 3.9)
- `onBrokenLinks` remains at root level (not deprecated)
- Build passes cleanly with no warnings

Closes #1

## Test plan

- [x] `npm run build` succeeds without deprecation warning