### PR TITLE
fix: Corriger projectName et editUrl (wiki-steami → wiki_steami)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -32,7 +32,7 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/steamicc/wiki_steami/tree/main/',
+          editUrl: 'https://github.com/steamicc/wiki_steami/edit/main/',
           showLastUpdateTime: true,
           showLastUpdateAuthor: true,
         },


### PR DESCRIPTION
## Summary

- Corrige `projectName` : `wiki-steami` → `wiki_steami` (underscore, comme le vrai nom du repo)
- Corrige `editUrl` : même correction pour que les liens "Edit this page" pointent vers le bon repo

Closes #30

## Test plan

- [x] `npm run build` passe sans erreur