### PR TITLE
ci: Ajouter un workflow de build automatique sur chaque PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,18 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
-  group: build-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -23,7 +29,9 @@ jobs:
       - run: npm ci
 
       - name: Build site
-        run: npm run build 2>&1 | tee build.log
+        run: |
+          set -o pipefail
+          npm run build 2>&1 | tee build.log
 
       - name: Check for broken links
         run: |


### PR DESCRIPTION
## Summary

Ajoute un workflow GitHub Actions `.github/workflows/build.yml` qui :
- Se déclenche sur chaque PR ciblant `main`
- Installe les dépendances (`npm ci`) avec Node 22
- Lance `npm run build`
- Vérifie la sortie pour détecter les liens cassés (grep "broken links")
- Échoue si des liens cassés sont détectés

### Caractéristiques
- Cohérent avec le workflow de deploy (même Node 22, même npm ci)
- Contrôle de concurrence : annule les builds obsolètes sur la même PR
- Non intrusif : ne modifie pas `docusaurus.config.js` (le build reste en mode `warn`, la CI grep la sortie)

Closes #66

## Test plan

- [x] Le workflow se déclenche bien sur cette PR
- [ ] Le build passe sans erreur
- [ ] Les liens cassés seraient détectés (testable en introduisant volontairement un lien mort)