### PR TITLE
fix: Restreindre lychee aux liens HTTP/HTTPS uniquement

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,8 +1,12 @@
 # Configuration lychee pour la vérification des liens externes
 # https://lychee.cli.rs/usage/config/
 
-# Accepter les codes de réponse courants
-accept = [200, 204, 301, 302]
+# Ne vérifier que les liens HTTP/HTTPS (ignorer les liens relatifs Markdown)
+include_mail = false
+scheme = ["https", "http"]
+
+# Accepter les codes de réponse courants (y compris 403 pour certains sites)
+accept = [200, 204, 301, 302, 403, 429]
 
 # Timeout par requête
 timeout = 30


### PR DESCRIPTION
## Problème

Le link checker lychee signalait des centaines de faux positifs car il essayait de résoudre les liens relatifs Markdown (ex: `../design/power`) comme des chemins de fichiers locaux. Ces liens sont valides dans Docusaurus mais n'existent pas en tant que fichiers sans l'extension `.md`.

## Solution

Ajout de `scheme = ["https", "http"]` dans `.lychee.toml` pour ne vérifier que les liens externes. Les liens internes Markdown sont déjà vérifiés par Docusaurus au build (`onBrokenLinks: 'warn'`).

Ajout de 403 et 429 dans les codes acceptés (sites avec rate limiting ou protection anti-bot).

## Test plan

- [x] CI build passe
- [ ] Relancer le workflow links manuellement après merge pour vérifier