### PR TITLE
fix: Exclure les sites incompatibles HTTP/2 du link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -25,11 +25,23 @@ max_retries = 3
 # Limiter la concurrence pour éviter le rate limiting
 max_concurrency = 3
 
-# Exclure les sites qui bloquent les requêtes automatisées malgré le user-agent
+# Exclure les sites incompatibles avec lychee
+# - localhost/example : pas de réseau
+# - st.com, tdk.com, te.com, molex.com : erreurs HTTP/2 (lychee ne supporte pas HTTP/1.1)
+# - yageo.com, smcdiode.com : connection reset (protection anti-bot)
+# - industrial.panasonic.com : timeout systématique
+# Ces liens sont valides dans un navigateur — vérification manuelle périodique recommandée
 exclude = [
   "localhost",
   "127\\.0\\.0\\.1",
   "example\\.com",
+  "www\\.st\\.com",
+  "www\\.tdk\\.com",
+  "www\\.te\\.com",
+  "www\\.molex\\.com",
+  "www\\.yageo\\.com",
+  "www\\.smcdiode\\.com",
+  "industrial\\.panasonic\\.com",
 ]
 
 # Exclure les répertoires


### PR DESCRIPTION
## Problème

L'issue #93 montre que le user-agent curl ne suffit pas — st.com, tdk.com, te.com, molex.com échouent toujours sur des erreurs HTTP/2 protocol. Lychee ne supporte pas le forçage HTTP/1.1 (ni globalement, ni par domaine).

## Solution

Exclure les domaines qui ont des incompatibilités HTTP/2 confirmées. Tous ces liens sont valides dans un navigateur — c'est un problème spécifique à lychee/reqwest.

### Domaines exclus

| Domaine | Erreur |
|---|---|
| st.com | HTTP/2 protocol error |
| tdk.com | HTTP/2 protocol error |
| te.com | HTTP/2 protocol error |
| molex.com | HTTP/2 protocol error |
| yageo.com | Connection reset (anti-bot) |
| smcdiode.com | Connection reset |
| industrial.panasonic.com | Timeout systématique |

Un commentaire dans le TOML recommande la vérification manuelle périodique de ces liens.

## Test plan

- [x] CI build passe
- [ ] Relancer le workflow links après merge — les erreurs HTTP/2 devraient disparaître