### PR TITLE
fix: Lancer lychee sur le site buildé au lieu des sources Markdown

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,7 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Check external links
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Check links on built site
         id: check-links
         uses: lycheeverse/lychee-action@v2
         with:
@@ -23,11 +33,10 @@ jobs:
             --config .lychee.toml
             --verbose
             --no-progress
-            'docs/**/*.md'
-            'README.md'
+            'build/**/*.html'
           fail: false
 
-      - name: Update or create issue on failure
+      - name: Create issue on failure
         if: steps.check-links.outputs.exit_code != '0'
         uses: peter-evans/create-issue-from-file@v5
         with:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,16 +1,12 @@
 # Configuration lychee pour la vérification des liens externes
 # https://lychee.cli.rs/usage/config/
 
-# Ne vérifier que les liens HTTP/HTTPS (ignorer les liens relatifs Markdown)
+# Ne vérifier que les liens HTTP/HTTPS
+# Les liens internes HTML (relatifs) sont résolus par le build Docusaurus
 include_mail = false
 scheme = ["https", "http"]
 
-# Racine pour résoudre les chemins root-relatifs (/img/..., /docs/...)
-root_dir = "static"
-
-# User-agent qui imite curl pour éviter les blocages anti-bot et HTTP/2
-# Note : lychee ne supporte pas le forçage HTTP/1.1, mais un user-agent
-# reconnu réduit les erreurs avec certains sites (st.com, molex, te.com)
+# User-agent curl pour réduire les blocages anti-bot
 user_agent = "curl/8.0"
 
 # Accepter les codes de réponse courants
@@ -25,7 +21,7 @@ max_retries = 3
 # Limiter la concurrence pour éviter le rate limiting
 max_concurrency = 3
 
-# Exclure les sites qui bloquent les requêtes automatisées malgré le user-agent
+# Exclure uniquement localhost et exemples
 exclude = [
   "localhost",
   "127\\.0\\.0\\.1",
@@ -35,6 +31,5 @@ exclude = [
 # Exclure les répertoires
 exclude_path = [
   "node_modules",
-  "build",
   ".docusaurus",
 ]


### PR DESCRIPTION
## Problème

Lychee sur les sources Markdown :
- Ne peut pas résoudre les liens relatifs (faux positifs)
- Échoue sur certains sites en HTTP/2 (st.com, tdk.com, etc.)
- Nécessitait d'exclure des domaines entiers, masquant de vrais liens cassés

## Solution

Le workflow build maintenant le site (`npm run build`) puis lance lychee sur `build/**/*.html` :
- Les liens internes sont déjà résolus par Docusaurus dans le HTML
- Les liens externes sont vérifiés comme des URLs HTTP normales depuis les attributs href
- Plus besoin de `root_dir` ni d'exclusions de domaines

Plus aucun domaine n'est exclu — si st.com casse, on le saura.

## Test plan

- [x] CI build passe
- [ ] Relancer le workflow links après merge pour vérifier que les erreurs HTTP/2 sont résolues