### PR TITLE
fix: Corrections review homepage (orthographe + meta description)

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -36,7 +36,7 @@ const features = [
 
 const specs = [
   { label: 'MCU', value: 'STM32WB55RG' },
-  { label: 'Coeur', value: 'Cortex-M4 @ 64 MHz' },
+  { label: 'Cœur', value: 'Cortex-M4 @ 64 MHz' },
   { label: 'Radio', value: 'BLE 5.2 / OpenThread / ZigBee' },
   { label: 'Capteurs', value: '7 capteurs internes' },
   { label: 'Écran', value: 'OLED 128×128' },
@@ -150,7 +150,7 @@ export default function Home() {
   return (
     <Layout
       title="Accueil"
-      description="Wiki STeaMi — Documentation technique de la carte STeaMi. Hardware, drivers MicroPython, pin mapping, conception."
+      description="Documentation STeaMi — Documentation technique de la carte STeaMi : hardware, drivers MicroPython, guides logiciels et ressources de développement."
     >
       <Hero />
       <Specs />


### PR DESCRIPTION
## Summary
- "Coeur" → "Cœur" (ligature française correcte)
- Meta description mise à jour : suppression de "Wiki STeaMi" et "pin mapping", alignement avec le nouveau branding

Suite aux commentaires Copilot sur la PR #116.

## Test plan
- [ ] Vérifier que "Cœur" s'affiche correctement dans les cartes specs
- [ ] Vérifier la meta description dans le code source de la page d'accueil