### PR TITLE
ci: Preview de déploiement sur les PRs (artifact + commentaire)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -59,3 +60,42 @@ jobs:
             exit 1
           fi
           echo "No broken links found"
+
+      - name: Upload build artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-preview
+          path: build/
+          retention-days: 7
+
+      - name: Comment PR with preview link
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `**Preview disponible** : le site a été buildé avec succès.\n\nTéléchargez l'artifact \`site-preview\` depuis [ce run](${runUrl}) pour prévisualiser le rendu localement (\`npx serve build/\`).`;
+
+            // Check for existing preview comment to avoid duplicates
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.data.find(c => c.body.includes('Preview disponible'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -60,42 +59,3 @@ jobs:
             exit 1
           fi
           echo "No broken links found"
-
-      - name: Upload build artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: site-preview
-          path: build/
-          retention-days: 7
-
-      - name: Comment PR with preview link
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = `**Preview disponible** : le site a été buildé avec succès.\n\nTéléchargez l'artifact \`site-preview\` depuis [ce run](${runUrl}) pour prévisualiser le rendu localement (\`npx serve build/\`).`;
-
-            // Check for existing preview comment to avoid duplicates
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.data.find(c => c.body.includes('Preview disponible'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = "build"
+
+[build.environment]
+  NODE_VERSION = "22"


### PR DESCRIPTION
## Summary
- Ajout de `netlify.toml` avec la config de build (Node 22, publish `build/`)
- Chaque PR recevra automatiquement une URL de deploy preview via Netlify

### Configuration Netlify (à faire manuellement)
1. Connecter le repo `steamicc/wiki_steami` sur [app.netlify.com](https://app.netlify.com)
2. Netlify détecte automatiquement le `netlify.toml`
3. Chaque PR recevra une URL de preview (ex: `deploy-preview-123--wiki-steami.netlify.app`)

Closes #72

## Test plan
- [ ] Connecter le repo sur Netlify
- [ ] Vérifier qu'une PR génère une deploy preview avec URL cliquable
- [ ] Vérifier que le build CI existant n'est pas impacté