### PR TITLE
chore: Ajouter CODEOWNERS pour la review automatique

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Default owner
+* @nedseb
+
+# Hardware documentation
+docs/hardware/ @nedseb
+
+# Software documentation
+docs/software/ @nedseb
+
+# Design and components
+docs/design/ @nedseb
+src/components/ @nedseb
+
+# CI/CD
+.github/ @nedseb


### PR DESCRIPTION
## Summary
- Ajout de `.github/CODEOWNERS` : @nedseb assigné comme reviewer par défaut sur toutes les PRs
- Sections spécifiques : hardware, software, design, components, CI/CD

Closes #73

## Test plan
- [ ] Vérifier que @nedseb est automatiquement assigné comme reviewer sur les prochaines PRs