### PR TITLE
ci: Auto-assignation des issues et PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -3,7 +3,7 @@ name: Auto Assign
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -19,4 +19,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: nedseb
           numOfAssignee: 1
-          allowSelfAssign: false
+          allowSelfAssign: true

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,22 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Auto-assign issue
+        uses: pozil/auto-assign-issue@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: nedseb
+          numOfAssignee: 1
+          allowSelfAssign: false


### PR DESCRIPTION
## Summary
- Workflow `auto-assign.yml` : assigne automatiquement @nedseb sur les issues et PRs ouvertes
- Basé sur le workflow de makecode-steami, adapté pour le wiki

Closes #85

## Test plan
- [ ] Vérifier que les prochaines issues/PRs sont automatiquement assignées